### PR TITLE
fix: set CMP0207 for runtime dependency scan

### DIFF
--- a/tests/test_install_deps_policy.py
+++ b/tests/test_install_deps_policy.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_install_deps_sets_cmp0207_before_runtime_dependency_scan(
+    top_level_dir: Path,
+):
+    template = (
+        top_level_dir
+        / "vtk_sdk_python_wheel_helper"
+        / "install-deps.cmake.in"
+    ).read_text(encoding="utf-8")
+
+    policy_position = template.index("cmake_policy(SET CMP0207 NEW)")
+    runtime_deps_position = template.index("file(GET_RUNTIME_DEPENDENCIES")
+
+    assert "if(POLICY CMP0207)" in template
+    assert policy_position < runtime_deps_position

--- a/vtk_sdk_python_wheel_helper/install-deps.cmake.in
+++ b/vtk_sdk_python_wheel_helper/install-deps.cmake.in
@@ -1,3 +1,7 @@
+if(POLICY CMP0207)
+  cmake_policy(SET CMP0207 NEW)
+endif()
+
 file(GET_RUNTIME_DEPENDENCIES
   RESOLVED_DEPENDENCIES_VAR resolved_deps
   UNRESOLVED_DEPENDENCIES_VAR unresolved_deps


### PR DESCRIPTION
Fixes #11

## Changes
- Set CMP0207 to NEW before calling `file(GET_RUNTIME_DEPENDENCIES)` when the policy exists.
- Add a regression test that checks the policy guard is emitted before the runtime dependency scan.

## Verification
- `python -m pytest tests/test_install_deps_policy.py -q`
- `python -m pytest --collect-only -q`

Note: full `python -m pytest` did not finish within 120 seconds in this local environment because the broader suite creates virtualenvs and builds/downloads VTK-related wheels.